### PR TITLE
Update ParitySpec.scala

### DIFF
--- a/src/test/scala/ParitySpec.scala
+++ b/src/test/scala/ParitySpec.scala
@@ -16,10 +16,15 @@ class ParitySpec extends WordSpec with MustMatchers {
       Parity.calculate(List(1,1,2,2,3)) mustEqual 3
     }
 
+    // There is no assert on this test?
     "Handle negative numbers" in {
       Parity.calculate(List(-2, -1, 1, 2))
     }
 
+    "Return the unique int" in {
+      Parity.calculate(List(1,-1,2,-2,3,3)) mustEqual 3
+    }
+    
   }
 
 }


### PR DESCRIPTION
I've added an extra test from the original kata spec. This test will fail with your current implementation.